### PR TITLE
chore: 依存関係を最新の互換範囲へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,23 +226,23 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -288,9 +288,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-            "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -345,9 +345,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+            "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
             "cpu": [
                 "ppc64"
             ],
@@ -362,9 +362,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+            "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
             "cpu": [
                 "arm"
             ],
@@ -379,9 +379,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+            "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
             "cpu": [
                 "arm64"
             ],
@@ -396,9 +396,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+            "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
             "cpu": [
                 "x64"
             ],
@@ -413,9 +413,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+            "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
             "cpu": [
                 "arm64"
             ],
@@ -430,9 +430,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+            "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
             "cpu": [
                 "x64"
             ],
@@ -447,9 +447,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
             "cpu": [
                 "arm64"
             ],
@@ -464,9 +464,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+            "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
             "cpu": [
                 "x64"
             ],
@@ -481,9 +481,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+            "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
             "cpu": [
                 "arm"
             ],
@@ -498,9 +498,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+            "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
             "cpu": [
                 "arm64"
             ],
@@ -515,9 +515,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+            "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
             "cpu": [
                 "ia32"
             ],
@@ -532,9 +532,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+            "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
             "cpu": [
                 "loong64"
             ],
@@ -549,9 +549,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+            "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
             "cpu": [
                 "mips64el"
             ],
@@ -566,9 +566,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+            "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
             "cpu": [
                 "ppc64"
             ],
@@ -583,9 +583,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+            "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
             "cpu": [
                 "riscv64"
             ],
@@ -600,9 +600,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+            "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
             "cpu": [
                 "s390x"
             ],
@@ -617,9 +617,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+            "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
             "cpu": [
                 "x64"
             ],
@@ -634,9 +634,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -651,9 +651,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
             "cpu": [
                 "x64"
             ],
@@ -668,9 +668,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+            "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
             "cpu": [
                 "arm64"
             ],
@@ -685,9 +685,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+            "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
             "cpu": [
                 "x64"
             ],
@@ -702,9 +702,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+            "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
             "cpu": [
                 "arm64"
             ],
@@ -719,9 +719,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+            "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
             "cpu": [
                 "x64"
             ],
@@ -736,9 +736,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+            "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
             "cpu": [
                 "arm64"
             ],
@@ -753,9 +753,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+            "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
             "cpu": [
                 "ia32"
             ],
@@ -770,9 +770,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+            "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
             "cpu": [
                 "x64"
             ],
@@ -816,15 +816,15 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.2"
+                "minimatch": "^3.1.5"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -888,9 +888,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-            "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -901,7 +901,7 @@
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.3",
+                "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
@@ -953,9 +953,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.3",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-            "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1533,9 +1533,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.3.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-            "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+            "version": "25.5.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+            "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.18.0"
@@ -1560,17 +1560,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-            "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/type-utils": "8.56.1",
-                "@typescript-eslint/utils": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/type-utils": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.4.0"
@@ -1583,22 +1583,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.56.1",
+                "@typescript-eslint/parser": "^8.57.1",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-            "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1614,14 +1614,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-            "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.56.1",
-                "@typescript-eslint/types": "^8.56.1",
+                "@typescript-eslint/tsconfig-utils": "^8.57.1",
+                "@typescript-eslint/types": "^8.57.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1636,14 +1636,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-            "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1"
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1654,9 +1654,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-            "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1671,15 +1671,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-            "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1",
-                "@typescript-eslint/utils": "8.56.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.4.0"
             },
@@ -1696,9 +1696,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-            "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1710,16 +1710,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-            "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.56.1",
-                "@typescript-eslint/tsconfig-utils": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/project-service": "8.57.1",
+                "@typescript-eslint/tsconfig-utils": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1738,16 +1738,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-            "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1"
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1762,13 +1762,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-            "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/types": "8.57.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1793,9 +1793,9 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-            "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+            "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1810,21 +1810,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-            "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+            "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.0.18",
-                "@vitest/utils": "4.0.18",
-                "chai": "^6.2.1",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "chai": "^6.2.2",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
@@ -1832,13 +1832,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-            "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+            "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.0.18",
+                "@vitest/spy": "4.1.0",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1847,7 +1847,7 @@
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^6.0.0 || ^7.0.0-0"
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -1859,9 +1859,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-            "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+            "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1872,13 +1872,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-            "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+            "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.0.18",
+                "@vitest/utils": "4.1.0",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1886,13 +1886,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-            "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+            "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.18",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/utils": "4.1.0",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1901,9 +1902,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-            "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+            "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1911,13 +1912,14 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-            "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+            "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.18",
+                "@vitest/pretty-format": "4.1.0",
+                "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
@@ -2172,9 +2174,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-            "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+            "version": "2.10.8",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+            "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2305,9 +2307,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001776",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
-            "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
+            "version": "1.0.30001779",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
+            "integrity": "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==",
             "dev": true,
             "funding": [
                 {
@@ -2564,9 +2566,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.307",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-            "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+            "version": "1.5.313",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+            "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
             "dev": true,
             "license": "ISC"
         },
@@ -2660,9 +2662,9 @@
             }
         },
         "node_modules/es-iterator-helpers": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-            "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
+            "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2681,6 +2683,7 @@
                 "has-symbols": "^1.1.0",
                 "internal-slot": "^1.1.0",
                 "iterator.prototype": "^1.1.5",
+                "math-intrinsics": "^1.1.0",
                 "safe-array-concat": "^1.1.3"
             },
             "engines": {
@@ -2688,9 +2691,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
             "license": "MIT"
         },
@@ -2755,9 +2758,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+            "version": "0.27.4",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+            "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2768,32 +2771,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.3",
-                "@esbuild/android-arm": "0.27.3",
-                "@esbuild/android-arm64": "0.27.3",
-                "@esbuild/android-x64": "0.27.3",
-                "@esbuild/darwin-arm64": "0.27.3",
-                "@esbuild/darwin-x64": "0.27.3",
-                "@esbuild/freebsd-arm64": "0.27.3",
-                "@esbuild/freebsd-x64": "0.27.3",
-                "@esbuild/linux-arm": "0.27.3",
-                "@esbuild/linux-arm64": "0.27.3",
-                "@esbuild/linux-ia32": "0.27.3",
-                "@esbuild/linux-loong64": "0.27.3",
-                "@esbuild/linux-mips64el": "0.27.3",
-                "@esbuild/linux-ppc64": "0.27.3",
-                "@esbuild/linux-riscv64": "0.27.3",
-                "@esbuild/linux-s390x": "0.27.3",
-                "@esbuild/linux-x64": "0.27.3",
-                "@esbuild/netbsd-arm64": "0.27.3",
-                "@esbuild/netbsd-x64": "0.27.3",
-                "@esbuild/openbsd-arm64": "0.27.3",
-                "@esbuild/openbsd-x64": "0.27.3",
-                "@esbuild/openharmony-arm64": "0.27.3",
-                "@esbuild/sunos-x64": "0.27.3",
-                "@esbuild/win32-arm64": "0.27.3",
-                "@esbuild/win32-ia32": "0.27.3",
-                "@esbuild/win32-x64": "0.27.3"
+                "@esbuild/aix-ppc64": "0.27.4",
+                "@esbuild/android-arm": "0.27.4",
+                "@esbuild/android-arm64": "0.27.4",
+                "@esbuild/android-x64": "0.27.4",
+                "@esbuild/darwin-arm64": "0.27.4",
+                "@esbuild/darwin-x64": "0.27.4",
+                "@esbuild/freebsd-arm64": "0.27.4",
+                "@esbuild/freebsd-x64": "0.27.4",
+                "@esbuild/linux-arm": "0.27.4",
+                "@esbuild/linux-arm64": "0.27.4",
+                "@esbuild/linux-ia32": "0.27.4",
+                "@esbuild/linux-loong64": "0.27.4",
+                "@esbuild/linux-mips64el": "0.27.4",
+                "@esbuild/linux-ppc64": "0.27.4",
+                "@esbuild/linux-riscv64": "0.27.4",
+                "@esbuild/linux-s390x": "0.27.4",
+                "@esbuild/linux-x64": "0.27.4",
+                "@esbuild/netbsd-arm64": "0.27.4",
+                "@esbuild/netbsd-x64": "0.27.4",
+                "@esbuild/openbsd-arm64": "0.27.4",
+                "@esbuild/openbsd-x64": "0.27.4",
+                "@esbuild/openharmony-arm64": "0.27.4",
+                "@esbuild/sunos-x64": "0.27.4",
+                "@esbuild/win32-arm64": "0.27.4",
+                "@esbuild/win32-ia32": "0.27.4",
+                "@esbuild/win32-x64": "0.27.4"
             }
         },
         "node_modules/escalade": {
@@ -2820,25 +2823,25 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.3",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-            "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+            "version": "9.39.4",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.1",
+                "@eslint/config-array": "^0.21.2",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.39.3",
+                "@eslint/eslintrc": "^3.3.5",
+                "@eslint/js": "9.39.4",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "ajv": "^6.12.4",
+                "ajv": "^6.14.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
@@ -2857,7 +2860,7 @@
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
+                "minimatch": "^3.1.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -3231,9 +3234,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-            "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -3561,9 +3564,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.14",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.14.tgz",
-            "integrity": "sha512-paMUYkfWJMsWPeE/Hejcw+XLhHrQPehem+4wMo+uELnvIwvCG019L9sAIljwjCmEMtFQQO3YeitJY8Kctei3iA==",
+            "version": "25.8.18",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
+            "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
             "funding": [
                 {
                     "type": "individual",
@@ -3580,7 +3583,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4"
+                "@babel/runtime": "^7.28.6"
             },
             "peerDependencies": {
                 "typescript": "^5"
@@ -4716,9 +4719,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "16.5.5",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.5.tgz",
-            "integrity": "sha512-5Z35e2JMALNR16FK/LDNQoAatQTVuO/4m4uHrIzewOPXIyf75gAHzuNLSWwmj5lRDJxDvXRJDECThkxWSAReng==",
+            "version": "16.5.8",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.8.tgz",
+            "integrity": "sha512-2ABeHHlakxVY+LSirD+OiERxFL6+zip0PaHo979bgwzeHg27Sqc82xxXWIrSFmfWX0ZkrvXMHwhsi/NGUf5VQg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.28.4",
@@ -5173,9 +5176,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5338,9 +5341,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5365,9 +5368,9 @@
             }
         },
         "node_modules/tinyrainbow": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-            "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5692,9 +5695,9 @@
             }
         },
         "node_modules/vite-plugin-singlefile": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.0.tgz",
-            "integrity": "sha512-DAcHzYypM0CasNLSz/WG0VdKOCxGHErfrjOoyIPiNxTPTGmO6rRD/te93n1YL/s+miXq66ipF1brMBikf99c6A==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.2.tgz",
+            "integrity": "sha512-b8SxCi/gG7K298oJDcKOuZeU6gf6wIcCJAaEqUmmZXdjfuONlkyNyWZC3tEbN6QockRCNUd3it9eGTtpHGoYmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5704,36 +5707,36 @@
                 "node": ">18.0.0"
             },
             "peerDependencies": {
-                "rollup": "^4.44.1",
-                "vite": "^5.4.11 || ^6.0.0 || ^7.0.0"
+                "rollup": "^4.59.0",
+                "vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/vitest": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-            "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+            "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.0.18",
-                "@vitest/mocker": "4.0.18",
-                "@vitest/pretty-format": "4.0.18",
-                "@vitest/runner": "4.0.18",
-                "@vitest/snapshot": "4.0.18",
-                "@vitest/spy": "4.0.18",
-                "@vitest/utils": "4.0.18",
-                "es-module-lexer": "^1.7.0",
-                "expect-type": "^1.2.2",
+                "@vitest/expect": "4.1.0",
+                "@vitest/mocker": "4.1.0",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/runner": "4.1.0",
+                "@vitest/snapshot": "4.1.0",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
                 "obug": "^2.1.1",
                 "pathe": "^2.0.3",
                 "picomatch": "^4.0.3",
-                "std-env": "^3.10.0",
+                "std-env": "^4.0.0-rc.1",
                 "tinybench": "^2.9.0",
                 "tinyexec": "^1.0.2",
                 "tinyglobby": "^0.2.15",
                 "tinyrainbow": "^3.0.3",
-                "vite": "^6.0.0 || ^7.0.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -5749,12 +5752,13 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.0.18",
-                "@vitest/browser-preview": "4.0.18",
-                "@vitest/browser-webdriverio": "4.0.18",
-                "@vitest/ui": "4.0.18",
+                "@vitest/browser-playwright": "4.1.0",
+                "@vitest/browser-preview": "4.1.0",
+                "@vitest/browser-webdriverio": "4.1.0",
+                "@vitest/ui": "4.1.0",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
@@ -5783,6 +5787,9 @@
                 },
                 "jsdom": {
                     "optional": true
+                },
+                "vite": {
+                    "optional": false
                 }
             }
         },


### PR DESCRIPTION
## 概要
依存関係を破壊的変更を含まない範囲（semver 互換）で更新しました。

## 変更内容
- `npm update` を実行し、`package-lock.json` を更新
- メジャーアップデートが必要な依存は対象外

## 動作確認
- `npm test` 実行
- 結果: 4 tests passed

## 補足
今回は lockfile のみ更新です。