### PR TITLE
chore: i18n関連ライブラリをメンテナンス

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3564,26 +3564,26 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.18",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
-            "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
+            "version": "25.10.3",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.3.tgz",
+            "integrity": "sha512-9XCjFgF7q4wNdmy7RFcDBIx1ndSXU3QwtbmqPjOdUxYxU9gbovJzZUY5Mb3ejWmDhxMl6Wmr2OenWOU3uyy6VQ==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
+                    "url": "https://www.locize.com/i18next"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.6"
+                "@babel/runtime": "^7.29.2"
             },
             "peerDependencies": {
                 "typescript": "^5"
@@ -4719,12 +4719,12 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "16.5.8",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.8.tgz",
-            "integrity": "sha512-2ABeHHlakxVY+LSirD+OiERxFL6+zip0PaHo979bgwzeHg27Sqc82xxXWIrSFmfWX0ZkrvXMHwhsi/NGUf5VQg==",
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.0.tgz",
+            "integrity": "sha512-bxVftl2q/pfupKVmBH80ui1rHl3ia2sdcR0Yhn6cr0PyoHfO8JLZ19fccwOIH+0dMBCIkdO5gAmEQFCTAggeQg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.4",
+                "@babel/runtime": "^7.29.2",
                 "html-parse-stringify": "^3.0.1",
                 "use-sync-external-store": "^1.6.0"
             },


### PR DESCRIPTION
## 概要
ライブラリメンテナンスとして、破壊的変更を伴わない i18n 関連依存の更新を行いました。

## 変更内容
- `i18next` を `25.8.18` → `25.10.3` に更新
- `react-i18next` を `16.5.8` → `16.6.0` に更新
- `package-lock.json` を更新

## 動作確認
- `npm test` を実行
- 結果: 4 tests passed