### PR TITLE
chore: i18next / react-i18next のパッチアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3564,9 +3564,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.10.5",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.5.tgz",
-            "integrity": "sha512-jRnF7eRNsdcnh7AASSgaU3lj/8lJZuHkfsouetnLEDH0xxE1vVi7qhiJ9RhdSPUyzg4ltb7P7aXsFlTk9sxL2w==",
+            "version": "25.10.9",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.9.tgz",
+            "integrity": "sha512-hQY9/bFoQKGlSKMlaCuLR8w1h5JjieqrsnZvEmj1Ja6Ec7fbyc4cTrCsY9mb9Sd8YQ/swsrKz1S9M8AcvVI70w==",
             "funding": [
                 {
                     "type": "individual",
@@ -3586,7 +3586,7 @@
                 "@babel/runtime": "^7.29.2"
             },
             "peerDependencies": {
-                "typescript": "^5"
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4719,9 +4719,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "16.6.2",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.2.tgz",
-            "integrity": "sha512-/S/GPzElTqEi5o2kzd0/O2627hPDmE6OGhJCCwCfUaQ3syyu+kaYH8/PYFtZeWc25NzfxTN/2fD1QjvrTgrFfA==",
+            "version": "16.6.6",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+            "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
@@ -4729,9 +4729,9 @@
                 "use-sync-external-store": "^1.6.0"
             },
             "peerDependencies": {
-                "i18next": ">= 25.6.2",
+                "i18next": ">= 25.10.9",
                 "react": ">= 16.8.0",
-                "typescript": "^5"
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "react-dom": {


### PR DESCRIPTION
## 概要
READMEに掲載されている `hash4word` の依存関係メンテナンスとして、破壊的変更のないパッチ更新を適用しました。

## 変更内容
- `i18next` を `25.10.5` → `25.10.9` に更新
- `react-i18next` を `16.6.2` → `16.6.6` に更新
- `package-lock.json` を更新

## 影響範囲
どちらも同一メジャー内のパッチ更新であり、このアプリの利用機能範囲では破壊的変更の影響はありません。

## 確認
- `npm test` 実行: 全テスト成功（4/4）