### PR TITLE
chore: viteを8.0.2へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "@vitejs/plugin-react": "^5.1.4",
                 "eslint": "^9.39.0",
                 "eslint-plugin-react": "^7.37.5",
-                "vite": "^7.3.1",
+                "vite": "^8.0.2",
                 "vite-plugin-singlefile": "^2.3.0",
                 "vitest": "^4.0.18"
             }
@@ -344,6 +344,40 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.4",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
@@ -357,6 +391,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -374,6 +409,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -391,6 +427,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -408,6 +445,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -425,6 +463,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -442,6 +481,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -459,6 +499,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -476,6 +517,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -493,6 +535,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -510,6 +553,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -527,6 +571,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -544,6 +589,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -561,6 +607,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -578,6 +625,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -595,6 +643,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -612,6 +661,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -629,6 +679,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -646,6 +697,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -663,6 +715,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -680,6 +733,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -697,6 +751,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -714,6 +769,7 @@
             "os": [
                 "openharmony"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -731,6 +787,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -748,6 +805,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -765,6 +823,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -782,6 +841,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1091,6 +1151,288 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+            "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+            "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+            "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+            "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+            "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+            "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+            "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+            "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-rc.3",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1110,7 +1452,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.60.0",
@@ -1124,7 +1467,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.60.0",
@@ -1138,7 +1482,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.60.0",
@@ -1152,7 +1497,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.60.0",
@@ -1166,7 +1512,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.60.0",
@@ -1180,7 +1527,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.60.0",
@@ -1194,7 +1542,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.60.0",
@@ -1208,7 +1557,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.60.0",
@@ -1222,7 +1572,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.60.0",
@@ -1236,7 +1587,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.60.0",
@@ -1250,7 +1602,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
             "version": "4.60.0",
@@ -1264,7 +1617,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.60.0",
@@ -1278,7 +1632,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
             "version": "4.60.0",
@@ -1292,7 +1647,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.60.0",
@@ -1306,7 +1662,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.60.0",
@@ -1320,7 +1677,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.60.0",
@@ -1334,7 +1692,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.60.0",
@@ -1348,7 +1707,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.60.0",
@@ -1362,7 +1722,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
             "version": "4.60.0",
@@ -1376,7 +1737,8 @@
             "optional": true,
             "os": [
                 "openbsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.60.0",
@@ -1390,7 +1752,8 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.60.0",
@@ -1404,7 +1767,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.60.0",
@@ -1418,7 +1782,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.60.0",
@@ -1432,7 +1797,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.60.0",
@@ -1446,7 +1812,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -1454,6 +1821,17 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -2537,6 +2915,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2764,6 +3152,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4177,6 +4567,267 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4878,12 +5529,54 @@
                 "node": ">=4"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+            "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.11"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.11",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+            "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/rollup": {
             "version": "4.60.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
             "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -5403,6 +6096,14 @@
                 "typescript": ">=4.8.4"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5620,17 +6321,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+            "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
+                "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.11",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -5647,9 +6347,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -5662,13 +6363,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "eslint": "^9.39.0",
         "eslint-plugin-react": "^7.37.5",
-        "vite": "^7.3.1",
+        "vite": "^8.0.2",
         "vite-plugin-singlefile": "^2.3.0",
         "vitest": "^4.0.18"
     }


### PR DESCRIPTION
## 概要
`vite` を `7.3.1` から `8.0.2` に更新しました。

## 変更内容
- `vite`: `7.3.1` → `8.0.2`
- lockfile 更新（`npm install`/`npm ci` による依存解決反映）

## 互換確認
- [x] `npm ci`
- [x] `npm test`（4/4 pass）
- [x] `npm run build`（pass）

## 補足
- build 時に `vite-plugin-singlefile` 由来の deprecation warning（`inlineDynamicImports`）が表示されますが、ビルド自体は成功しています。
