### PR TITLE
chore: react-i18next を v17 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-hot-toast": "^2.6.0",
-                "react-i18next": "^16.5.4",
+                "react-i18next": "^17.0.0",
                 "react-router-dom": "^7.13.1",
                 "universal-base64url": "^1.1.0",
                 "use-sound": "^5.0.0",
@@ -2094,9 +2094,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "16.6.6",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-            "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.0.tgz",
+            "integrity": "sha512-L7aqwOePCExt6nlF7000lN2YKWnR7IpSpQId9sj01798Xn3LAncBdTHKl9lA/nr+YrG78BTqWPJxq9mlrrmH7Q==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
@@ -2104,7 +2104,7 @@
                 "use-sync-external-store": "^1.6.0"
             },
             "peerDependencies": {
-                "i18next": ">= 25.10.9",
+                "i18next": ">= 25.10.10",
                 "react": ">= 16.8.0",
                 "typescript": "^5 || ^6"
             },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",
-        "react-i18next": "^16.5.4",
+        "react-i18next": "^17.0.0",
         "react-router-dom": "^7.13.1",
         "universal-base64url": "^1.1.0",
         "use-sound": "^5.0.0",


### PR DESCRIPTION
## 概要
react-i18next を `^16.5.4` から `^17.0.0` へ更新しました。

## 変更内容
- `react-i18next`: `^16.5.4` → `^17.0.0`

## 破壊的変更の確認
- 参照: https://raw.githubusercontent.com/i18next/react-i18next/v17.0.0/CHANGELOG.md
- v17.0.0 の Potentially breaking changes は `Trans` の自動生成キー時のHTMLタグ保持挙動に関する修正
- 本アプリでは `useTranslation()` のみ利用しており、`<Trans>` を利用していないため、機能利用範囲への影響はないと判断

## 検証
- `npm test` ✅
- `npm run build` ✅

## 補足
- メジャー更新は1依存関係のみを単独PRで実施しています。
