### PR TITLE
chore: non-major依存関係を更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "hash4word",
             "version": "1.0.0",
             "dependencies": {
-                "@types/node": "^25.3.0",
+                "@types/node": "^25.5.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
                 "i18next": "^25.10.10",
@@ -16,7 +16,7 @@
                 "react-dom": "^19.2.4",
                 "react-hot-toast": "^2.6.0",
                 "react-i18next": "^17.0.0",
-                "react-router-dom": "^7.13.1",
+                "react-router-dom": "^7.13.2",
                 "universal-base64url": "^1.1.0",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
@@ -25,7 +25,7 @@
                 "@vitejs/plugin-react": "^6.0.1",
                 "typescript": "^6.0.2",
                 "vite": "^8.0.3",
-                "vite-plugin-singlefile": "^2.3.0",
+                "vite-plugin-singlefile": "^2.3.2",
                 "vitest": "^4.1.2"
             }
         },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "homepage": "./",
     "dependencies": {
-        "@types/node": "^25.3.0",
+        "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "i18next": "^25.10.10",
@@ -11,7 +11,7 @@
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",
         "react-i18next": "^17.0.0",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.13.2",
         "universal-base64url": "^1.1.0",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"
@@ -32,7 +32,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "typescript": "^6.0.2",
         "vite": "^8.0.3",
-        "vite-plugin-singlefile": "^2.3.0",
+        "vite-plugin-singlefile": "^2.3.2",
         "vitest": "^4.1.2"
     }
 }


### PR DESCRIPTION
## 概要
non-major（パッチ/マイナー）依存関係をまとめて更新しました。

## 変更内容
- `@types/node`: `^25.3.0` → `^25.5.0`
- `react-router-dom`: `^7.13.1` → `^7.13.2`
- `vite-plugin-singlefile`: `^2.3.0` → `^2.3.2`

## 検証
- `npm test` ✅
- `npm run build` ✅
