### PR TITLE
chore: i18next を v26.0.1 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.5.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^25.10.10",
+                "i18next": "^26.0.1",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-hot-toast": "^2.6.0",
@@ -1631,9 +1631,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.10.10",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-            "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+            "version": "26.0.1",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
+            "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^25.10.10",
+        "i18next": "^26.0.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
## 概要
- i18next を 25.10.10 から 26.0.1 へ更新しました（メジャー更新を単独PRで実施）

## 変更内容
- i18next のみ更新
- lockfile を更新

## 事前確認（Breaking Changes）
- i18next v26.0.0 のリリースノートを確認
- 破壊的変更として `initImmediate` 廃止・`interpolation.format` 旧形式廃止などを確認
- 本リポジトリではこれら該当オプションの利用がなく、影響範囲内で問題ないことを確認

## 検証
- `npm test` : 成功
- `npm run build` : 成功

## 備考
- CI成功を確認後にマージします。