### PR TITLE
chore: react-i18next を 17.0.1 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-hot-toast": "^2.6.0",
-                "react-i18next": "^17.0.0",
+                "react-i18next": "^17.0.1",
                 "react-router-dom": "^7.13.2",
                 "universal-base64url": "^1.1.0",
                 "use-sound": "^5.0.0",
@@ -2094,9 +2094,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.0.tgz",
-            "integrity": "sha512-L7aqwOePCExt6nlF7000lN2YKWnR7IpSpQId9sj01798Xn3LAncBdTHKl9lA/nr+YrG78BTqWPJxq9mlrrmH7Q==",
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.1.tgz",
+            "integrity": "sha512-iG65FGnFHcYyHNuT01ukffYWCOBFTWSdVD8EZd/dCVWgtjFPObcSsvYYNwcsokO/rDcTb5d6D8Acv8MrOdm6Hw==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
@@ -2104,7 +2104,7 @@
                 "use-sync-external-store": "^1.6.0"
             },
             "peerDependencies": {
-                "i18next": ">= 25.10.10",
+                "i18next": ">= 26.0.1",
                 "react": ">= 16.8.0",
                 "typescript": "^5 || ^6"
             },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",
-        "react-i18next": "^17.0.0",
+        "react-i18next": "^17.0.1",
         "react-router-dom": "^7.13.2",
         "universal-base64url": "^1.1.0",
         "use-sound": "^5.0.0",


### PR DESCRIPTION
## 概要
- react-i18next を 17.0.0 から 17.0.1 へ更新しました

## 変更内容
- react-i18next のみ更新
- lockfile を更新

## 事前確認（変更ログ）
- `npm view react-i18next@17.0.1 peerDependencies` を確認し、`i18next >=26.0.1` が必要なことを確認
- 先行して i18next を 26.0.1 に更新済みであり、依存条件を満たしていることを確認

## 検証
- `npm test` : 成功
- `npm run build` : 成功

## 備考
- CI成功を確認後にマージします。
