### PR TITLE
chore: i18next を v26 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.5.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^26.0.1",
+                "i18next": "^26.0.2",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-hot-toast": "^2.6.0",
@@ -1631,9 +1631,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "26.0.1",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.1.tgz",
-            "integrity": "sha512-vtz5sXU4+nkCm8yEU+JJ6yYIx0mkg9e68W0G0PXpnOsmzLajNsW5o28DJMqbajxfsfq0gV3XdrBudsDQnwxfsQ==",
+            "version": "26.0.2",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.2.tgz",
+            "integrity": "sha512-WsK0SdP+7tGzsxpT+Us1s2nvOyx657DatBodaNZe4KcPTPYzkVfRKUygN69mB+sCbbnifRuKz+Ya5JRzd8DNHw==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^26.0.1",
+        "i18next": "^26.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
## 概要
- `i18next` を `^25.8.11` から `^26.0.2` へ更新しました（メジャーアップデート）。
- ルールに従い、メジャー更新はこの依存関係のみを1PRで実施しています。

## 変更内容
- `package.json` の `i18next` バージョン更新
- `package-lock.json` の追随更新

## Breaking Changes の確認
- 確認先: https://github.com/i18next/i18next/releases/tag/v26.0.0
- v26 の主な破壊的変更:
  - `initImmediate` 廃止（`initAsync` へ）
  - 旧 `interpolation.format` 廃止
  - `showSupportNotice` 関連廃止
  - `simplifyPluralSuffix` 廃止
- 本リポジトリの `src/i18n/configs.ts` では上記廃止オプションを使用していないことを確認済みです。

## 検証
- `npm test` ✅
- `npm run build` ✅
- GitHub Actions `CI`（PR上）✅
