### PR TITLE
chore: CIにsafe-chainを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Install dependencies
         run: npm ci
       - name: Run tests

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -30,8 +30,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: build
-        run: npm ci && npm run build
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## 概要
`hash4word` の GitHub Actions に AikidoSec の `safe-chain` を導入しました。

## 変更内容
- `.github/workflows/ci.yml`
  - Node セットアップ後に `safe-chain` インストールステップを追加
  - その後 `npm ci` を実行
- `.github/workflows/gh_pages.yml`
  - Node セットアップ後に `safe-chain` インストールステップを追加
  - 既存の `npm ci && npm run build` を分割して、`npm ci` を safe-chain 配下で実行する形に変更

追加したコマンド:
```bash
curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
```

## 目的
`kurehajime/kurehajime` からリンクされている JavaScript 系リポジトリへ順次 safe-chain を導入するための最初の1件です。
