### PR TITLE
chore: i18next を 26.0.5 へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.6.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^26.0.4",
+                "i18next": "^26.0.5",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "react-hot-toast": "^2.6.0",
@@ -1635,9 +1635,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "26.0.4",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
-            "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
+            "version": "26.0.5",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.5.tgz",
+            "integrity": "sha512-9uHb4T27TdV36phJXcbpnRPt5yzAfqHXVrdASvmHZyPuZJtrLythd+GyXhiaHV5LlpuuskbAqhwPjmfTbKbi8w==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^26.0.4",
+        "i18next": "^26.0.5",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
## 概要
- `i18next` を `^26.0.4` から `^26.0.5` へ更新
- ローカルで `npm test` と `npm run build` を実行し、既存挙動に影響がないことを確認

## 確認
- `npm test`
- `npm run build`
