### PR TITLE
chore: 依存関係を更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,17 +15,17 @@
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "react-hot-toast": "^2.6.0",
-                "react-i18next": "^17.0.2",
-                "react-router-dom": "^7.14.0",
+                "react-i18next": "^17.0.4",
+                "react-router-dom": "^7.14.1",
                 "universal-base64url": "^1.1.0",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
             },
             "devDependencies": {
                 "@vitejs/plugin-react": "^6.0.1",
-                "typescript": "^6.0.2",
+                "typescript": "^6.0.3",
                 "vite": "^8.0.8",
-                "vite-plugin-singlefile": "^2.3.2",
+                "vite-plugin-singlefile": "^2.3.3",
                 "vitest": "^4.1.4"
             }
         },
@@ -2098,9 +2098,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.2.tgz",
-            "integrity": "sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==",
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+            "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
@@ -2125,9 +2125,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-            "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+            "version": "7.14.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+            "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -2147,12 +2147,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-            "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+            "version": "7.14.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+            "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.14.0"
+                "react-router": "7.14.1"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -2209,6 +2209,7 @@
             "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
@@ -2358,9 +2359,9 @@
             "optional": true
         },
         "node_modules/typescript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2502,9 +2503,9 @@
             }
         },
         "node_modules/vite-plugin-singlefile": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.2.tgz",
-            "integrity": "sha512-b8SxCi/gG7K298oJDcKOuZeU6gf6wIcCJAaEqUmmZXdjfuONlkyNyWZC3tEbN6QockRCNUd3it9eGTtpHGoYmg==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+            "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2515,7 +2516,12 @@
             },
             "peerDependencies": {
                 "rollup": "^4.59.0",
-                "vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+                "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.6.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^26.0.4",
+                "i18next": "^26.0.5",
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "react-hot-toast": "^2.6.0",
@@ -1635,9 +1635,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "26.0.4",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
-            "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
+            "version": "26.0.5",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.5.tgz",
+            "integrity": "sha512-9uHb4T27TdV36phJXcbpnRPt5yzAfqHXVrdASvmHZyPuZJtrLythd+GyXhiaHV5LlpuuskbAqhwPjmfTbKbi8w==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-hot-toast": "^2.6.0",
-        "react-i18next": "^17.0.2",
-        "react-router-dom": "^7.14.0",
+        "react-i18next": "^17.0.4",
+        "react-router-dom": "^7.14.1",
         "universal-base64url": "^1.1.0",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"
@@ -30,9 +30,9 @@
     },
     "devDependencies": {
         "@vitejs/plugin-react": "^6.0.1",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "vite": "^8.0.8",
-        "vite-plugin-singlefile": "^2.3.2",
+        "vite-plugin-singlefile": "^2.3.3",
         "vitest": "^4.1.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^26.0.4",
+        "i18next": "^26.0.5",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
## 概要
- `react-i18next` を `^17.0.2` から `^17.0.4` へ更新
- `react-router-dom` を `^7.14.0` から `^7.14.1` へ更新
- `typescript` を `^6.0.2` から `^6.0.3` へ更新
- `vite-plugin-singlefile` を `^2.3.2` から `^2.3.3` へ更新

## 見送り
- `i18next` `^26.0.6`
  - ローカルでは `npm test` / `npm run build` は成功
  - ただし PR CI の `npm ci` が safe-chain の minimum package age により `i18next@26.0.6` をブロックしたため、今回の更新対象から外しました

## 補足
- semver範囲外（major）更新も確認対象に含めて調査しましたが、このリポジトリでは今回対象となる major 更新候補はありませんでした。

## 検証
- `npm test` ✅
- `npm run build` ✅

## CI
- Pull Request の `CI` 成功後にマージします。
