### PR TITLE
chore: 一時的な safe-chain overrides を外す

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,6 @@
             "react-app"
         ]
     },
-    "overrides": {
-        "postcss": "8.5.12",
-        "nanoid": "3.3.11"
-    },
     "devDependencies": {
         "@vitejs/plugin-react": "^6.0.1",
         "typescript": "^6.0.3",


### PR DESCRIPTION
## 概要
- `hash4word` で一時的に入れていた `overrides` を除去
- 対象:
  - `postcss: 8.5.12`
  - `nanoid: 3.3.11`

## 補足
- 今回は `package-lock.json` を触っていないため、直近の `npm ci` では従来 lockfile の解決結果が使われる
- つまり、このPRは「固定設定を外す」こと自体が主目的
- 今後 lockfile 更新時には再び newer version を取りにいく状態へ戻る

## 確認
- `npm ls postcss nanoid --all`
- `npm test`
- `npm run build`
