### PR TITLE
chore: vitest を 4.1.5 へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "typescript": "^6.0.3",
                 "vite": "^8.0.10",
                 "vite-plugin-singlefile": "^2.3.3",
-                "vitest": "^4.1.4"
+                "vitest": "^4.1.5"
             }
         },
         "node_modules/@babel/runtime": {
@@ -1312,16 +1312,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-            "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1330,13 +1330,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-            "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.4",
+                "@vitest/spy": "4.1.5",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1357,9 +1357,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-            "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1370,13 +1370,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-            "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.4",
+                "@vitest/utils": "4.1.5",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1384,14 +1384,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-            "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1400,9 +1400,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-            "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1410,13 +1410,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-            "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.4",
+                "@vitest/pretty-format": "4.1.5",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2522,19 +2522,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-            "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.4",
-                "@vitest/mocker": "4.1.4",
-                "@vitest/pretty-format": "4.1.4",
-                "@vitest/runner": "4.1.4",
-                "@vitest/snapshot": "4.1.4",
-                "@vitest/spy": "4.1.4",
-                "@vitest/utils": "4.1.4",
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -2562,12 +2562,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.4",
-                "@vitest/browser-preview": "4.1.4",
-                "@vitest/browser-webdriverio": "4.1.4",
-                "@vitest/coverage-istanbul": "4.1.4",
-                "@vitest/coverage-v8": "4.1.4",
-                "@vitest/ui": "4.1.4",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vite-plugin-singlefile": "^2.3.3",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.5"
     }
 }


### PR DESCRIPTION
## 概要
- `vitest` を `^4.1.4` から `^4.1.5` へ更新した
- semver 内の更新なので依存関係の最小変更に留めた

## 確認
- `npm test`
- `npm run build`
- PR CI
