### PR TITLE
Dependabot の更新を multi-ecosystem にグルーピング

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,34 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    patterns:
+      - "*"
     schedule:
       interval: "weekly"
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 2
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    schedule:
+      interval: "weekly"
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
     cooldown:
       default-days: 2


### PR DESCRIPTION
### Motivation
- Dependabot の個別 PR を可能な限りまとめて管理し、雑多な更新 PR を減らすために multi-ecosystem grouping を導入します。

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups` と `dependency-updates` グループを追加しました。
- `npm` と `github-actions` の `updates` エントリを `multi-ecosystem-group: "dependency-updates"` に割り当てし、`patterns: ["*"]` でワイルドカードを設定しました。
- npm と GitHub Actions それぞれに対してワイルドカードのセキュリティ更新グループ（`all-npm-security-updates` / `all-github-actions-security-updates`）を追加しました。
- 既存の `schedule` を週次のまま維持し、`cooldown: default-days: 2` も残しています。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"]&.key?("dependency-updates"); abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; abort("missing update grouping") unless data["updates"].all? { |u| u["multi-ecosystem-group"] == "dependency-updates" && u["patterns"] == ["*"] && u["groups"].is_a?(Hash) }; puts "dependabot.yml is valid YAML"'` を実行して成功しました。
- `git diff --check` を実行して差分に問題がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b80cba5c83268973fa427873c595)