### PR TITLE
npm registry を flatt.tech に設定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 min-release-age=2880
+registry=https://npm.flatt.tech


### PR DESCRIPTION
### Motivation
- プロジェクトの npm レジストリを特定のミラーに固定するため、`https://npm.flatt.tech` を設定します。

### Description
- ルートの `/.npmrc` に `registry=https://npm.flatt.tech` を追記し、既存の `min-release-age` 設定は維持しました。

### Testing
- 設定ファイルのみの変更のため自動テストは実行しておらず、`git status --short` と `nl -ba .npmrc` で差分を確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0442f808b883268a3f30ab5c93cd53)