### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,34 @@
 version: 2
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    patterns:
-      - "*"
     schedule:
       interval: "weekly"
-    multi-ecosystem-group: "dependency-updates"
+    cooldown:
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    cooldown:
-      default-days: 2
+
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns:
-      - "*"
     schedule:
       interval: "weekly"
-    multi-ecosystem-group: "dependency-updates"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-github-actions-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    cooldown:
-      default-days: 2


### PR DESCRIPTION
### Motivation
- 参照先の設定に合わせてDependabotの挙動を整理し、通常のminor/patch更新ノイズを抑えつつセキュリティ更新は適切に扱うための変更です。

### Description
- `.github/dependabot.yml`を更新し、`npm`および`github-actions`のチェックを週次に設定しました。
- 通常のminor/patch更新を無視する設定を追加し、`npm`に対して`cooldown`として`default-days: 7`と`semver-major-days: 60`を設定しました。
- セキュリティ更新はそれぞれ`all-npm-security-updates`と`all-github-actions-security-updates`でグループ化しました。
- 既存のmulti-ecosystemグループ設定を簡素化しました。

### Testing
- `python - <<'PY' ... PY`による基本内容チェックを実行し成功しました。
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`によるYAML構文チェックを実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21c8694883269567e955eb73d5e9)